### PR TITLE
New Release v1.5.0 for OCI Service Broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[1.5.0]
+
+- Adding support for Chuncheon (YNY), Hyderabad (HYD) and  Sanjose (SJC) regions
+- Minor Bug Fix to make OCI Service Broker compatible with 1.16+
+
 [1.4.0]
 
 - Adding support for Osaka (KIX), Melbourne (MEL), Amsterdam (AMS), Jeddah (JED), Montreal (YUL) regions

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the [Documentation](charts/oci-service-broker/README.md#oci-service-broker) 
 The OCI Service Broker is packaged as Helm chart for making it easy to install in Kubernetes Clusters. The chart can be downloaded from below URL.
 
 ```
-https://github.com/oracle/oci-service-broker/releases/download/v1.4.0/oci-service-broker-1.4.0.tgz
+https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz
 ```
 
 ## Samples

--- a/charts/oci-service-broker/Chart.yaml
+++ b/charts/oci-service-broker/Chart.yaml
@@ -5,4 +5,4 @@
 apiVersion: v1
 description: A Helm chart for installing OCI Service Broker into a Kubernetes cluster
 name: oci-service-broker
-version: 1.4.0
+version: 1.5.0

--- a/charts/oci-service-broker/docs/installation.md
+++ b/charts/oci-service-broker/docs/installation.md
@@ -75,7 +75,7 @@ brew update && brew install kubernetes-service-catalog-client
 The OCI Service Broker is packaged as Helm chart for making it easy to install in Kubernetes. The chart is available at [charts/oci-service-broker](../) directory.
 
 ```plain
-https://github.com/oracle/oci-service-broker/releases/download/v1.4.0/oci-service-broker-1.4.0.tgz
+https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz
 ```
 
 ### OCI credentials
@@ -114,7 +114,7 @@ For quickly testing out OCI Service Broker, TLS can be disabled and an embedded 
 
 Helm 3.x syntax:
 ```bash
- helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.4.0/oci-service-broker-1.4.0.tgz \
+ helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz \
   --set ociCredentials.secretName=ocicredentials \
   --set storage.etcd.useEmbedded=true \
   --set tls.enabled=false
@@ -122,7 +122,7 @@ Helm 3.x syntax:
 
 Helm 2.x syntax:
 ```bash
- helm install https://github.com/oracle/oci-service-broker/releases/download/v1.4.0/oci-service-broker-1.4.0.tgz  --name oci-service-broker \
+ helm install https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz  --name oci-service-broker \
   --set ociCredentials.secretName=ocicredentials \
   --set storage.etcd.useEmbedded=true \
   --set tls.enabled=false
@@ -226,7 +226,7 @@ Replace the values of --set arguments with your appropriate values to install th
 
 Helm 3.x syntax:
 ```bash
- helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.4.0/oci-service-broker-1.4.0.tgz \
+ helm install oci-service-broker https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz \
   --set ociCredentials.secretName=ocicredentials \
   --set tls.secretName=certsecret \
   --set storage.etcd.servers=<comma separated list of etcd servers>
@@ -234,7 +234,7 @@ Helm 3.x syntax:
 
 Helm 2.x syntax:
 ```bash
- helm install https://github.com/oracle/oci-service-broker/releases/download/v1.4.0/oci-service-broker-1.4.0.tgz --name oci-service-broker \
+ helm install https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz --name oci-service-broker \
   --set ociCredentials.secretName=ocicredentials \
   --set tls.secretName=certsecret \
   --set storage.etcd.servers=<comma separated list of etcd servers>
@@ -288,7 +288,7 @@ Refer [Restrict access to Service Catalog resources using RBAC](security.md#rest
 Sample files for various services are available under [`oci-service-broker/samples`](../samples) directory inside the charts. The below command extracts chart that contains the sample files.
 
 ```bash
-curl -LO https://github.com/oracle/oci-service-broker/releases/download/v1.4.0/oci-service-broker-1.4.0.tgz | tar xz
+curl -LO https://github.com/oracle/oci-service-broker/releases/download/v1.5.0/oci-service-broker-1.5.0.tgz | tar xz
 ```
 
 Create a `ClusterServiceBroker` resource with OCI Service Broker URL to register the broker. Use the below register yaml file after updating the namespace of the OCI Service Broker.

--- a/charts/oci-service-broker/templates/deployment.yaml
+++ b/charts/oci-service-broker/templates/deployment.yaml
@@ -13,7 +13,7 @@
   {{- end }}
 {{- end }}
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "oci-service-broker-chart.fullname" . }}
@@ -24,6 +24,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "oci-service-broker-chart.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/charts/oci-service-broker/values.yaml
+++ b/charts/oci-service-broker/values.yaml
@@ -11,10 +11,11 @@ replicaCount: 1
 # Image of the broker
 image:
   # Repository of the image
-  repository: iad.ocir.io/oracle/oci-service-broker
+  #repository: iad.ocir.io/oracle/oci-service-broker
+  repository: iad.ocir.io/oci-cnp-dev/oci-service-broker
 
   # Tag of the image
-  tag:  1.4.0
+  tag:  1.5.0
 
   # The image pull policy
   pullPolicy: Always

--- a/oci-service-broker/build.gradle
+++ b/oci-service-broker/build.gradle
@@ -30,14 +30,14 @@ apply plugin: 'maven-publish'
 archivesBaseName = 'oci-service-broker'
 
 // Sometimes, the version has to be overridden from command line
-version = project.hasProperty('version_num') ? project.getProperty('version_num') : '1.4.0'
+version = project.hasProperty('version_num') ? project.getProperty('version_num') : '1.5.0'
 ext.dockerGroup = 'iad.ocir.io/oci-cnp-dev'
 mainClassName = 'com.oracle.oci.osb.Broker'
 
 sourceCompatibility = 10
 
 ext {
-    ociSdkVersion = "1.13.2"
+    ociSdkVersion = "1.22.1"
     jerseyVersion = "2.27"
     hk2Version = "2.5.0-b42"
     hamcrestVersion = "1.3"

--- a/oci-service-broker/download_SDK_libs.sh
+++ b/oci-service-broker/download_SDK_libs.sh
@@ -9,7 +9,7 @@
 #sdk jars and their dependency jars. The jars are written to libs directory.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SDK_VERSION="1.13.2"
+SDK_VERSION="1.22.1"
 TEMP_DIR="/tmp/oci-java-sdk"
 rm -rf ${TEMP_DIR}
 mkdir -p ${TEMP_DIR} 
@@ -17,7 +17,7 @@ mkdir -p ${SCRIPT_DIR}/libs
 echo "Downloading oci-java-sdk version v${SDK_VERSION} and the dependent libraries..."
 curl -sSL https://github.com/oracle/oci-java-sdk/releases/download/v${SDK_VERSION}/oci-java-sdk.zip -o ${TEMP_DIR}/oci-java-sdk.zip
 unzip -qq ${TEMP_DIR}/oci-java-sdk.zip -d ${TEMP_DIR}
-cp ${TEMP_DIR}/lib/oci-java-sdk-full-1.13.2.jar ${SCRIPT_DIR}/libs/
+cp ${TEMP_DIR}/lib/oci-java-sdk-full-1.22.1.jar ${SCRIPT_DIR}/libs/
 cp ${TEMP_DIR}/third-party/lib/*.jar  ${SCRIPT_DIR}/libs/
 rm -rf ${TEMP_DIR}
 echo "oci-java-sdk and the dependent libraries are downloaded to ${SCRIPT_DIR}/libs directory"


### PR DESCRIPTION
- Adding support for Chuncheon (YNY), Hyderabad (HYD) and  Sanjose (SJC) regions
- Minor Bug Fix to make OCI Service Broker compatible with 1.16+

Co-authored-by: Ashokkumar Kannan ashokkumar.kannan@oracle.com
Co-authored-by: Jayasheelan Kumar jayasheelan.kumar@oracle.com