### PR TITLE
New Release v1.5.0 for OCI Service Broker

### DIFF
--- a/charts/oci-service-broker/values.yaml
+++ b/charts/oci-service-broker/values.yaml
@@ -11,8 +11,7 @@ replicaCount: 1
 # Image of the broker
 image:
   # Repository of the image
-  #repository: iad.ocir.io/oracle/oci-service-broker
-  repository: iad.ocir.io/oci-cnp-dev/oci-service-broker
+  repository: iad.ocir.io/oracle/oci-service-broker
 
   # Tag of the image
   tag:  1.5.0

--- a/oci-service-broker/download_SDK_libs.sh
+++ b/oci-service-broker/download_SDK_libs.sh
@@ -15,7 +15,7 @@ rm -rf ${TEMP_DIR}
 mkdir -p ${TEMP_DIR} 
 mkdir -p ${SCRIPT_DIR}/libs
 echo "Downloading oci-java-sdk version v${SDK_VERSION} and the dependent libraries..."
-curl -sSL https://github.com/oracle/oci-java-sdk/releases/download/v${SDK_VERSION}/oci-java-sdk.zip -o ${TEMP_DIR}/oci-java-sdk.zip
+curl -sSL https://github.com/oracle/oci-java-sdk/releases/download/v${SDK_VERSION}/oci-java-sdk-${SDK_VERSION}.zip -o ${TEMP_DIR}/oci-java-sdk.zip
 unzip -qq ${TEMP_DIR}/oci-java-sdk.zip -d ${TEMP_DIR}
 cp ${TEMP_DIR}/lib/oci-java-sdk-full-1.22.1.jar ${SCRIPT_DIR}/libs/
 cp ${TEMP_DIR}/third-party/lib/*.jar  ${SCRIPT_DIR}/libs/


### PR DESCRIPTION
- Adding support for Chuncheon (YNY), Hyderabad (HYD) and  Sanjose (SJC) regions
- Minor Bug Fix to make OCI Service Broker compatible with 1.16+

Co-authored-by: Ashokkumar Kannan ashokkumar.kannan@oracle.com
Co-authored-by: Jayasheelan Kumar jayasheelan.kumar@oracle.com